### PR TITLE
CoffeeScript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "autocomplete-webgl",
   "version": "1.1.0",
   "repository": "https://github.com/hughsk/autocomplete-webgl",
+  "description" : "WebGL completion for Atom.",
   "dependencies": {
     "fuzzaldrin": "^2.1.0",
     "gl-api": "^1.0.3",


### PR DESCRIPTION
Hi Hugh,

I'm using CoffeeScript for writing WebGL, and I needed your extension to work also on *.coffee files. So I modified the provider for the methods to support Coffee script files by checking the editor's grammar.

I added a package description too because without it some markdown text from the github page was appearing instead.
